### PR TITLE
Enable stdin as file input

### DIFF
--- a/command.go
+++ b/command.go
@@ -90,11 +90,21 @@ func appendFile(filename string, data []byte, success func() Message, error func
 	return []Message{success()}
 }
 
-func readFile(filename string, success func([]byte) Message, error func(error) Message) []Message {
-	content, err := ioutil.ReadFile(filename)
+func readFile(filename string, success func([]byte) Message, errorFunc func(error) Message) []Message {
+	var (
+		content []byte
+		err     error
+	)
+
+	if filename == "-" {
+		content, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		content, err = ioutil.ReadFile(filename)
+	}
+
 	if err != nil {
-		if error != nil {
-			return []Message{error(err)}
+		if errorFunc != nil {
+			return []Message{errorFunc(err)}
 		}
 		return noMessages
 	}

--- a/init.go
+++ b/init.go
@@ -12,7 +12,7 @@ func Init(args []string, env map[string]string) (State, []Command) {
 	state := *NewState(0, DefaultPhrase)
 
 	commandLine := flag.NewFlagSet(args[0], flag.ContinueOnError)
-	datafile := commandLine.String("f", "/usr/share/dict/words", "load word list from `FILE`")
+	datafile := commandLine.String("f", "/usr/share/dict/words", "load word list from `FILE`. \"-\" for stdin.")
 	commandLine.BoolVar(&state.Codelines, "c", false, "treat -f FILE as lines of code")
 	commandLine.Bool("d", false, "demo mode for screenshot")
 	commandLine.Float64Var(&state.NumberProb, "n", 0, "mix in numbers with `PROBABILITY`")


### PR DESCRIPTION
I added this change on my local gotypist because it serves my usecase.

Basically to practice typing code, I use `gotypist -c -f some-code-sample.py`
But of course I end up having always the beginning first.

This change allows me to do `shuf < some-code-sample.py | gotypist -c -f -` which gives lines in a random order without having to go through a temporary file