### PR TITLE
Improve windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 gotypist
+*.exe
+.gotypist.stats

--- a/init.go
+++ b/init.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"strings"
 	"time"
+	"os"
+	"path/filepath"
 )
 
 func Init(args []string, env map[string]string) (State, []Command) {
@@ -43,8 +45,12 @@ func Init(args []string, env map[string]string) (State, []Command) {
 		})
 	}
 
-	home, _ := env["HOME"]
-	state.Statsfile = home + "/.gotypist.stats"
+	exe, err := os.Executable()
+	if err != nil {
+		return State{}, []Command{Exit{Status: 1, GoodbyeMessage: err.Error()}}
+	}
+
+	state.Statsfile = filepath.Join(filepath.Dir(exe), ".gotypist.stats")
 
 	return state, append(commands,
 		ReadFile{


### PR DESCRIPTION
The `HOME` environment variable doesn't exist on Windows, so the program would crash when trying to write to the stats file. I changed it so that the stats file is stored in the same directory as the executable. I prefer this since when you're going to delete the program when you no longer need it, it's easier to see that file and delete it as well, and it keeps things more self-contained, rather than it cluttering up your home directory without you realizing it.

If you disagree with this decision, using the `os.UserHomeDir()` function would be another option.